### PR TITLE
feat(BE): update post implementation

### DIFF
--- a/backend/auth/dependencies.py
+++ b/backend/auth/dependencies.py
@@ -1,5 +1,4 @@
-from fastapi import Depends, Header, status
-from fastapi.responses import JSONResponse
+from fastapi import Depends, Header, HTTPException, status
 from sqlalchemy.orm import Session
 
 from auth.jwt_handler import decode_token
@@ -11,24 +10,27 @@ from repository.user import check_if_email_is_already_registered
 
 def get_current_user(token: str = Header(), db: Session = Depends(get_db)) -> User:
     payload = decode_token(token)
+
     if not payload:
-        return JSONResponse(
+        raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
-            content={"id": INVALID_OR_EXPIRED_TOKEN},
+            detail={"id": INVALID_OR_EXPIRED_TOKEN},
         )
 
     email = payload.get("sub")
+
     if not email:
-        return JSONResponse(
+        raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
-            content={"id": PAYLOAD_MISSING_SUB},
+            detail={"id": PAYLOAD_MISSING_SUB},
         )
 
     user = check_if_email_is_already_registered(db, email)
+
     if not user:
-        return JSONResponse(
+        raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            content={"id": USER_NOT_FOUND},
+            detail={"id": USER_NOT_FOUND},
         )
 
     return user

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,4 +1,4 @@
-from fastapi import FastAPI, Request
+from fastapi import FastAPI, HTTPException, Request
 from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
@@ -76,4 +76,18 @@ async def validation_exception_handler(request: Request, exc: RequestValidationE
     return JSONResponse(
         status_code=HTTP_422_UNPROCESSABLE_ENTITY,
         content=formatted_errors,
+    )
+
+
+@app.exception_handler(HTTPException)
+async def http_exception_handler(request: Request, exc: HTTPException):
+    if isinstance(exc.detail, dict) and "id" in exc.detail:
+        return JSONResponse(
+            status_code=exc.status_code,
+            content=exc.detail,
+        )
+
+    return JSONResponse(
+        status_code=exc.status_code,
+        content={"detail": exc.detail},
     )

--- a/backend/repository/post.py
+++ b/backend/repository/post.py
@@ -4,12 +4,13 @@ from fastapi import Depends
 from sqlalchemy.orm import Session
 
 from auth.dependencies import get_current_user
+from core.constants import POST_NOT_FOUND
 from models.post import Post
-from schemas.post import PostCreate
+from schemas.post import PostUpdate
 
 
 def create_post(
-    db: Session, post: PostCreate, user_id: str = Depends(get_current_user)
+    db: Session, post: Post, user_id: str = Depends(get_current_user)
 ) -> Post:
     db_post = Post(title=post.title, content=post.content, author_id=user_id)
 
@@ -21,3 +22,20 @@ def create_post(
 
 def get_post_by_id(db: Session, post_id: UUID) -> Post:
     return db.query(Post).filter(Post.id == post_id).first()
+
+
+def update_post(db: Session, post_id: UUID, update_data: PostUpdate) -> Post:
+    post = db.query(Post).filter(Post.id == post_id).first()
+
+    if not post:
+        raise ValueError(POST_NOT_FOUND)
+
+    if update_data.title is not None:
+        post.title = update_data.title
+
+    if update_data.content is not None:
+        post.content = update_data.content
+
+    db.commit()
+    db.refresh(post)
+    return post

--- a/backend/routes/post.py
+++ b/backend/routes/post.py
@@ -9,15 +9,15 @@ from auth.dependencies import get_current_user
 from connection import get_db
 from core.constants import GENERIC_ERROR, POST_NOT_FOUND
 from models.user import User
-from repository.post import create_post, get_post_by_id
-from schemas.post import PostCreate, PostResponse
+from repository.post import create_post, get_post_by_id, update_post
+from schemas.post import Post, PostResponse
 
 router = APIRouter()
 
 
 @router.post("/posts", response_model=PostResponse, status_code=status.HTTP_201_CREATED)
 async def create(
-    post: PostCreate,
+    post: Post,
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
@@ -45,3 +45,30 @@ async def get_post(post_id: UUID, db: Session = Depends(get_db)):
         )
 
     return PostResponse.model_validate(post)
+
+
+@router.patch("/posts/{post_id}", response_model=PostResponse)
+async def update(
+    post_id: UUID,
+    update_data: Post,
+    db: Session = Depends(get_db),
+    User=Depends(get_current_user),
+):
+    try:
+        post = update_post(db, post_id, update_data)
+
+        return PostResponse.model_validate(post)
+
+    except ValueError:
+        db.rollback()
+        return JSONResponse(
+            status_code=status.HTTP_404_NOT_FOUND,
+            content={"id": POST_NOT_FOUND},
+        )
+
+    except SQLAlchemyError:
+        db.rollback()
+        return JSONResponse(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            content={"id": GENERIC_ERROR},
+        )

--- a/backend/routes/post.py
+++ b/backend/routes/post.py
@@ -47,7 +47,7 @@ async def get_post(post_id: UUID, db: Session = Depends(get_db)):
     return PostResponse.model_validate(post)
 
 
-@router.patch("/posts/{post_id}", response_model=PostResponse)
+@router.put("/posts/{post_id}", response_model=PostResponse)
 async def update(
     post_id: UUID,
     update_data: Post,

--- a/backend/schemas/post.py
+++ b/backend/schemas/post.py
@@ -1,18 +1,24 @@
 from datetime import datetime
+from typing import Optional
 from uuid import UUID
 
 from pydantic import BaseModel
 
 
-class PostCreate(BaseModel):
+class Post(BaseModel):
     title: str
     content: str
 
 
-class PostResponse(PostCreate):
+class PostResponse(Post):
     id: UUID
     created_at: datetime
     author_id: UUID
 
     class Config:
         from_attributes = True
+
+
+class PostUpdate(BaseModel):
+    title: Optional[str] = None
+    content: Optional[str] = None


### PR DESCRIPTION
- Refactor Auth Layer:
Replaces direct JSONResponse returns with HTTPException raises to leverage FastAPI's native exception handling mechanism.

- Add Custom HTTPException Handler:
Introduces a global HTTPException handler that formats error responses with a custom structure (e.g., `{ "id": "invalid_or_expired_token" }`), improving client-side error parsing.

- Rename PostCreate to Post:
Generalizes the post input schema to Post for broader use beyond creation, aligning better with PATCH operations.