### PR TITLE
feat(BE): list all posts using generic pagination logic

### DIFF
--- a/backend/repository/post.py
+++ b/backend/repository/post.py
@@ -7,6 +7,7 @@ from auth.dependencies import get_current_user
 from core.constants import POST_NOT_FOUND
 from models.post import Post
 from schemas.post import PostUpdate
+from utils import pagination
 
 
 def create_post(
@@ -27,6 +28,11 @@ def get_post_by_id(db: Session, post_id: UUID) -> Post:
         .filter(Post.id == post_id)
         .first()
     )
+
+
+def get_paginated_posts(db: Session, offset: int = 0, limit: int = 10) -> Post:
+    query = db.query(Post)
+    return pagination.paginate(query, offset, limit)
 
 
 def update_post(db: Session, post_id: UUID, update_data: PostUpdate) -> Post:

--- a/backend/schemas/pagination.py
+++ b/backend/schemas/pagination.py
@@ -1,0 +1,12 @@
+from typing import Generic, List, TypeVar
+
+from pydantic.generics import GenericModel
+
+T = TypeVar("T")
+
+
+class PaginatedResponse(GenericModel, Generic[T]):
+    total: int
+    has_next: bool
+    has_prev: bool
+    items: List[T]

--- a/backend/utils/pagination.py
+++ b/backend/utils/pagination.py
@@ -1,0 +1,16 @@
+from math import ceil
+
+
+def paginate(query, page: int, limit: int):
+    total = query.count()
+    pages = max(ceil(total / limit), 1)
+    offset = (page - 1) * limit
+
+    items = query.offset(offset).limit(limit).all()
+
+    return {
+        "total": total,
+        "has_next": page < pages,
+        "has_prev": page > 1,
+        "items": items,
+    }


### PR DESCRIPTION
Implementation of paginated listing for all posts.

Created the PaginatedResponse schema using GenericModel to support various data types.

Added the `paginate()` function in `utils/pagination.py` with support for:

- Automatic calculation of `total, pages, has_next, and has_prev`