### PR TITLE
feat(BE): implement delete post with owner verification

### DIFF
--- a/backend/core/constants.py
+++ b/backend/core/constants.py
@@ -14,6 +14,7 @@ NEW_PASSWORD_SAME_AS_OLD = "old_password_same_as_new_password"
 REQUIRED_FIELDS_MISSING = "required_fields_missing"
 USER_NOT_FOUND = "user_not_found"
 POST_NOT_FOUND = "post_not_found"
+FORBIDDEN = "user_not_authorized"
 
 PYDANTIC_FIELD_REQUIRED_MSG = "Field required"
 PYDANTIC_EMAIL_ALREADY_REGISTERED_MSG = "Email already registered"

--- a/backend/repository/post.py
+++ b/backend/repository/post.py
@@ -4,7 +4,7 @@ from fastapi import Depends
 from sqlalchemy.orm import Session, joinedload
 
 from auth.dependencies import get_current_user
-from core.constants import POST_NOT_FOUND
+from core.constants import FORBIDDEN, POST_NOT_FOUND
 from models.post import Post
 from schemas.post import PostUpdate
 from utils import pagination
@@ -50,3 +50,16 @@ def update_post(db: Session, post_id: UUID, update_data: PostUpdate) -> Post:
     db.commit()
     db.refresh(post)
     return post
+
+
+def delete_post(db: Session, post_id: int, user_id: int):
+    post = db.query(Post).filter(Post.id == post_id).first()
+
+    if not post:
+        raise ValueError(POST_NOT_FOUND)
+
+    if post.author_id != user_id:
+        raise PermissionError(FORBIDDEN)
+
+    db.delete(post)
+    db.commit()


### PR DESCRIPTION
Implemented `delete_post()` in the repository layer, with ownership check via user_id.

Updated the /posts/{post_id} route to:

- Accept the authenticated user (current_user)
- Return `404` if the post does not exist
- Return `403` if the user is not the post owner

Handled errors using JSONResponse for consistent API responses.